### PR TITLE
Keep other 3th party repos enabled as much as possible

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -5,8 +5,8 @@ use esmith::Build::CreateLinks qw(:all);
 
 my $event = "nethserver-danb35-update";
 templates2events("/etc/sudoers", $event);
+templates2events("/etc/nethserver/eorepo.conf", $event);
 
-
-event_actions($event,
-             'danb35_enablerepo' => '10',
-);
+#event_actions($event,
+#
+#);

--- a/root/etc/e-smith/events/actions/danb35_enablerepo
+++ b/root/etc/e-smith/events/actions/danb35_enablerepo
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-echo '[NOTICE] applying new YUM repository configuration'
-exec /sbin/e-smith/signal-event software-repos-save
-
-


### PR DESCRIPTION
- Omit running signal-event software-repos-save explicitly

One does not need to run signal-event software-repos-save to install and enable the required repo.
Running software-repos-save often confuses people, especially on non-subscription, as it disables all repositories not listed in /etc/nethserver/eorepo.conf

Also see:
stephdl/dev#18